### PR TITLE
fix: BaseTimeEntity 적용 안되던 문제 해결

### DIFF
--- a/src/main/java/egenius/settlement/SettlementApplication.java
+++ b/src/main/java/egenius/settlement/SettlementApplication.java
@@ -2,10 +2,12 @@ package egenius.settlement;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class SettlementApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/egenius/settlement/domain/paysettlement/application/SettlementServiceImpl.java
+++ b/src/main/java/egenius/settlement/domain/paysettlement/application/SettlementServiceImpl.java
@@ -76,9 +76,10 @@ public class SettlementServiceImpl implements SettlementService {
             String productMainImageUrl,
             PaymentMethod paymentMethod
     ) {
-        // 정산 내용 조회
+        // 정산 내용 조회 -> 결제날짜가 아닌 생성날짜이므로, 오늘~내일 사이에 생성되어야한다
         LocalDateTime stt = LocalDate.now().atStartOfDay();
         LocalDateTime end = LocalDate.now().plusDays(1).atStartOfDay();
+        log.info("stt: "+stt+", end: "+end);
         QDailyProductSettlement qDailyProductSettlement = QDailyProductSettlement.dailyProductSettlement;
 
         // 날짜와 ProductCode로 productSettlement를 조회한다
@@ -90,6 +91,7 @@ public class SettlementServiceImpl implements SettlementService {
                             .and(qDailyProductSettlement.createdAt.lt(end))
                             .and(qDailyProductSettlement.productCode.eq(productCode)))
                     .fetchOne();
+            log.info("product result: "+productSettlement);
             // null이 아니라면 update
             if (productSettlement != null) {
                 productSettlement.addCount(count);

--- a/src/main/java/egenius/settlement/domain/paysettlement/entity/DailyProductSettlement.java
+++ b/src/main/java/egenius/settlement/domain/paysettlement/entity/DailyProductSettlement.java
@@ -26,10 +26,10 @@ public class DailyProductSettlement extends BaseTimeEntity {
     @Column(name = "product_daily_total_amount")
     private Integer productDailyTotalAmount; // 상품별 일일 총 정산금액
 
-    @Column(name = "daily_card_amount", columnDefinition = "default int 0")
+    @Column(name = "daily_card_amount", columnDefinition = "int default 0")
     private Integer dailyCardAmount; // 상품별 카드 결제금액
 
-    @Column(name = "daily_pay_amount", columnDefinition = "default int 0")
+    @Column(name = "daily_pay_amount", columnDefinition = "int default 0")
     private Integer dailyPayAmount; // 상품별 페이 결제금액 - 카카오, 네이버, 토스 모두 더해서 준다
 
     @Column(name = "count")

--- a/src/main/java/egenius/settlement/global/common/BaseTimeEntity.java
+++ b/src/main/java/egenius/settlement/global/common/BaseTimeEntity.java
@@ -1,13 +1,16 @@
 package egenius.settlement.global.common;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@EntityListeners(AuditingEntityListener.class) // Auditing(자동 값 매핑)기능 추가
 @Getter
 @MappedSuperclass // 멤버 인스턴스가, entity의 컬럼으로 들어가도록 해줌
 public abstract class BaseTimeEntity {

--- a/src/main/java/egenius/settlement/global/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/egenius/settlement/global/config/kafka/KafkaConsumerConfig.java
@@ -47,7 +47,7 @@ public class KafkaConsumerConfig {
         props.put(GROUP_ID_CONFIG, "test1");
         props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-//        props.put(MAX_POLL_RECORDS_CONFIG, 10);
+//        props.put(MAX_POLL_RECORDS_CONFIG, 3);
         return props;
     }
 }


### PR DESCRIPTION
# 버그 해결 💊
 - BaseTimeEntity : @EntityListeners 추가
 - SettlementApplication : @EnableJpaAuditing 추가
 - SettlementServiceImpl : stt와 end를 하루씩 뒤로 미룸 -> paidAt이 아닌 createdAt으로 조회하기 때문


# 스크린샷 🖼
 - 조회 성공
 ![image](https://github.com/Spharos-GentleDog/BE-settlement/assets/108791919/959ca051-326a-4b8d-9ae4-59464037452d)

- 동일 코드를 가진 제품 정보가 새로 생성되는것이 아니라 업데이트 되는 로직 성공
<img width="617" alt="image" src="https://github.com/Spharos-GentleDog/BE-settlement/assets/108791919/eeb677d4-7da1-4d3f-8852-3230883232b8">

