### PR TITLE
refactor: 사용하지 않는 kafka설정 주석처리 및 topic 이름 변경

### DIFF
--- a/src/main/java/egenius/settlement/domain/batch/jobs/PaymentSaveJob.java
+++ b/src/main/java/egenius/settlement/domain/batch/jobs/PaymentSaveJob.java
@@ -83,16 +83,16 @@ public class PaymentSaveJob {
     // 3. reader
     @Bean
     public KafkaItemReader<String, String> kafkaItemReader() {
-        // kafka consumer
+        // kafka consumer -> kafkaItemReader는 컨슈머 하나만 설정 가능
         List<Integer> partitions = Arrays.asList(0, 1, 2, 3, 4);
         KafkaItemReader<String, String> dailyPaymentSaveItemReader = new KafkaItemReaderBuilder<String, String>()
                 .partitions(partitions)
                 .partitionOffsets(new HashMap<>()) //모름
                 .consumerProperties(dailyPaymentSaveProps)
                 .name("dailyPaymentSaveItemReader")
-                .saveState(true) // 모름
-                .pollTimeout(Duration.ofSeconds(1L))
-                .topic("payment_data")
+                .saveState(true) // 현재까지 읽은 상태를 저장. 재시작할 때 중단된 지점부터 다시 읽을 수 있음
+                .pollTimeout(Duration.ofSeconds(10L))
+                .topic("payment_topic")
                 .build();
         return dailyPaymentSaveItemReader;
     }

--- a/src/main/java/egenius/settlement/global/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/egenius/settlement/global/config/kafka/KafkaConsumerConfig.java
@@ -21,32 +21,32 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapAddress;
 
-    @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(createConsumer());
-        factory.setConcurrency(5);
-        return factory;
-    }
+//    @Bean
+//    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+//        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+//        factory.setConsumerFactory(createConsumer());
+//        factory.setConcurrency(5);
+//        return factory;
+//    }
+//
+//    @Bean
+//    public ConsumerFactory<String, String> createConsumer() {
+//        Map<String, Object> configs = new HashMap<>();
+//        configs.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+//        configs.put(GROUP_ID_CONFIG, "payment_group");
+//        // key, value에 대한 직렬화 설정 -> Byte array, String, Integer Serializer를 사용할 수 있다
+//        // 메시지를 가져올 파티션의 key를 역직렬화
+//        configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+//        // value는 메시지라 보면 됨
+//        configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+//        return new DefaultKafkaConsumerFactory<>(configs);
+//    }
 
-    @Bean
-    public ConsumerFactory<String, String> createConsumer() {
-        Map<String, Object> configs = new HashMap<>();
-        configs.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
-        configs.put(GROUP_ID_CONFIG, "test1");
-        // key, value에 대한 직렬화 설정 -> Byte array, String, Integer Serializer를 사용할 수 있다
-        // 메시지를 가져올 파티션의 key를 역직렬화
-        configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        // value는 메시지라 보면 됨
-        configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        return new DefaultKafkaConsumerFactory<>(configs);
-    }
-
+    // paymentJob에서 KafkaItemReader를 사용하기 위한 설정
     @Bean
     public Properties dailyPaymentSaveProps() {
         Properties props = new Properties();
         props.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
-        props.put(GROUP_ID_CONFIG, "test1");
         props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 //        props.put(MAX_POLL_RECORDS_CONFIG, 3);


### PR DESCRIPTION
# 구현 및 변경점 👍
 - KafkaConsumerConfig : kafkaItemReader에서 사용하는 props를 제외하고 모두 주석처리, topic이름을 payment_topic으로 변경
