### PR TITLE
fix: kafkaConfig에 groupid 빠진부분 수정

### DIFF
--- a/src/main/java/egenius/settlement/global/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/egenius/settlement/global/config/kafka/KafkaConsumerConfig.java
@@ -47,6 +47,7 @@ public class KafkaConsumerConfig {
     public Properties dailyPaymentSaveProps() {
         Properties props = new Properties();
         props.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        props.put(GROUP_ID_CONFIG, "payment_group");
         props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 //        props.put(MAX_POLL_RECORDS_CONFIG, 3);


### PR DESCRIPTION
# 버그 해결 💊
 - KafkaConsumerConfig : consumer Props에서 group Id 셋팅은 필수 -> 누락된 부분 추가